### PR TITLE
handle width where min not working; alpha release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/ipeca-ui",
-  "version": "0.1.4",
+  "version": "0.1.5-a1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/src/qrcode-popup.tsx
+++ b/src/qrcode-popup.tsx
@@ -86,8 +86,11 @@ const styleEditingArea = css`
   border: 8px solid #aaa;
   min-width: 320px;
   min-height: 320px;
-  max-width: 600px;
-  max-height: 600px;
+  max-width: 640px;
+  max-height: 640px;
+  /* in case min() does not work */
+  width: 640px;
+  height: 640px;
   width: min(60vw, 60vh);
   height: min(60vw, 60vh);
   margin-top: 12vh;


### PR DESCRIPTION
远程调试发现 `height: min(60vw, 60vh);` 在 PWA 方式打开的页面当中不生效. 添加默认的大小, 针对当前设备定的 640px.